### PR TITLE
Fixed incorrect path in Dockerfile for ch03-nerd-dinner-db:2e

### DIFF
--- a/ch03/ch03-nerd-dinner-db/Dockerfile
+++ b/ch03/ch03-nerd-dinner-db/Dockerfile
@@ -30,4 +30,4 @@ COPY Initialize-Database.ps1 .
 CMD powershell ./Initialize-Database.ps1 -sa_password $env:sa_password -data_path $env:data_path -Verbose
 
 COPY --from=builder ["C:\\Program Files\\Microsoft SQL Server\\140\\DAC", "C:\\Program Files\\Microsoft SQL Server\\140\\DAC"]
-COPY --from=builder C:\src\NerdDinner.Database\bin\Debug\NerdDinner.Database.dacpac .
+COPY --from=builder C:\docker\NerdDinner.Database.dacpac .


### PR DESCRIPTION
Path was incorrect on last COPY line. This fix was made in the first edition but not here in the second edition.